### PR TITLE
Introduced Spark 2.2.1 via SparkSessionBuilder instead of deprecated …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.9</version>
+            <version>4.12</version>
         </dependency>
 
         <dependency>
@@ -112,19 +112,19 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>
-            <version>1.6.1</version>
+            <version>2.2.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.10</artifactId>
-            <version>1.6.1</version>
+            <version>2.2.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_2.10</artifactId>
-            <version>1.6.1</version>
+            <version>2.2.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.finra.hiveqlunit</groupId>
     <artifactId>hiveQLUnit</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>HiveQLUnit</name>

--- a/src/main/java/org/finra/hiveqlunit/rules/SetUpHql.java
+++ b/src/main/java/org/finra/hiveqlunit/rules/SetUpHql.java
@@ -85,7 +85,7 @@ public class SetUpHql implements TestRule {
          */
         @Override
         public void evaluate() throws Throwable {
-            setUpHql.runScript(testingHiveServer.getHiveContext());
+            setUpHql.runScript(testingHiveServer.getSqlContext());
             wrappedStatement.evaluate();
         }
     }

--- a/src/main/java/org/finra/hiveqlunit/rules/TearDownHql.java
+++ b/src/main/java/org/finra/hiveqlunit/rules/TearDownHql.java
@@ -91,7 +91,7 @@ public class TearDownHql implements TestRule {
             try {
                 wrappedStatement.evaluate();
             } finally {
-                tearDownHql.runScript(testingHiveServer.getHiveContext());
+                tearDownHql.runScript(testingHiveServer.getSqlContext());
             }
         }
     }

--- a/src/main/java/org/finra/hiveqlunit/rules/TestDataLoader.java
+++ b/src/main/java/org/finra/hiveqlunit/rules/TestDataLoader.java
@@ -85,7 +85,7 @@ public class TestDataLoader implements TestRule {
             writer.print(tableData);
             writer.close();
 
-            hiveServer.getHiveContext().sql("LOAD DATA LOCAL INPATH '"
+            hiveServer.getSqlContext().sql("LOAD DATA LOCAL INPATH '"
                     + stagingFile.getAbsolutePath().replace("\\", "/")
                     + "' INTO TABLE "
                     + tableName

--- a/src/main/java/org/finra/hiveqlunit/script/HqlScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/HqlScript.java
@@ -17,7 +17,9 @@
 package org.finra.hiveqlunit.script;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.SQLContext;
+
+import java.util.List;
 
 /**
  * Abstracts the execution of hql scripts or expressions. How to handle comments in scripts,
@@ -29,17 +31,17 @@ public interface HqlScript {
     /**
      * Runs the hql script or expressions represented by this HqlScript using a HiveContext.
      *
-     * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      */
-    public void runScript(HiveContext hqlContext);
+    public void runScript(SQLContext sqlContext);
 
     /**
      * Runs the hql script or expressions represented by this HqlScript using a HiveContext,
      * returning a results set from the script.
      *
-     * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an sqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      * @return a result set of Rows produced by running the hql script or expressions represented by this HqlScript
      */
-    public Row[] runScriptReturnResults(HiveContext hqlContext);
+    public List<Row> runScriptReturnResults(SQLContext sqlContext);
 
 }

--- a/src/main/java/org/finra/hiveqlunit/script/HqlScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/HqlScript.java
@@ -29,9 +29,9 @@ import java.util.List;
 public interface HqlScript {
 
     /**
-     * Runs the hql script or expressions represented by this HqlScript using a HiveContext.
+     * Runs the sql script or expressions represented by this HqlScript using a HiveContext.
      *
-     * @param sqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SQLContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      */
     public void runScript(SQLContext sqlContext);
 
@@ -39,7 +39,7 @@ public interface HqlScript {
      * Runs the hql script or expressions represented by this HqlScript using a HiveContext,
      * returning a results set from the script.
      *
-     * @param sqlContext an sqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SQLContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      * @return a result set of Rows produced by running the hql script or expressions represented by this HqlScript
      */
     public List<Row> runScriptReturnResults(SQLContext sqlContext);

--- a/src/main/java/org/finra/hiveqlunit/script/MultiExpressionScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/MultiExpressionScript.java
@@ -17,8 +17,10 @@
 package org.finra.hiveqlunit.script;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.SQLContext;
 import org.finra.hiveqlunit.resources.TextResource;
+
+import java.util.List;
 
 /**
  * Runs an hql script containing multiple expressions, using the ScriptSplitter utility to
@@ -44,10 +46,10 @@ public class MultiExpressionScript implements HqlScript {
      * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      */
     @Override
-    public void runScript(HiveContext hqlContext) {
+    public void runScript(SQLContext sqlContext) {
         String[] expressions = ScriptSplitter.splitScriptIntoExpressions(script);
         for (String expression : expressions) {
-            hqlContext.sql(expression);
+            sqlContext.sql(expression);
         }
     }
 
@@ -55,16 +57,19 @@ public class MultiExpressionScript implements HqlScript {
      * Splits the bundled hql script into multiple expressions using ScriptSlitter utility class.
      * Each expression is run on the provided HiveContext.
      *
-     * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      * @return the row results acquired from the last executed expression
      */
     @Override
-    public Row[] runScriptReturnResults(HiveContext hqlContext) {
+    public List<Row> runScriptReturnResults(SQLContext sqlContext) {
         String[] expressions = ScriptSplitter.splitScriptIntoExpressions(script);
         for (int i = 0; i < expressions.length - 1; i++) {
             String expression = expressions[i];
-            hqlContext.sql(expression);
+            sqlContext.sql(expression);
         }
-        return hqlContext.sql(expressions[expressions.length - 1]).collect();
+
+        List<Row> rows = sqlContext.sql(expressions[expressions.length - 1]).collectAsList();
+        return rows;
+        //return sqlContext.sql(expressions[expressions.length - 1]).collectAsList();
     }
 }

--- a/src/main/java/org/finra/hiveqlunit/script/MultiExpressionScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/MultiExpressionScript.java
@@ -43,7 +43,7 @@ public class MultiExpressionScript implements HqlScript {
      * Splits the bundled hql script into multiple expressions using ScriptSlitter utility class.
      * Each expression is run on the provided HiveContext.
      *
-     * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SQLContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      */
     @Override
     public void runScript(SQLContext sqlContext) {

--- a/src/main/java/org/finra/hiveqlunit/script/MultiExpressionScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/MultiExpressionScript.java
@@ -57,7 +57,7 @@ public class MultiExpressionScript implements HqlScript {
      * Splits the bundled hql script into multiple expressions using ScriptSlitter utility class.
      * Each expression is run on the provided HiveContext.
      *
-     * @param sqlContext an SqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SQLContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      * @return the row results acquired from the last executed expression
      */
     @Override
@@ -70,6 +70,5 @@ public class MultiExpressionScript implements HqlScript {
 
         List<Row> rows = sqlContext.sql(expressions[expressions.length - 1]).collectAsList();
         return rows;
-        //return sqlContext.sql(expressions[expressions.length - 1]).collectAsList();
     }
 }

--- a/src/main/java/org/finra/hiveqlunit/script/SingleExpressionScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/SingleExpressionScript.java
@@ -17,8 +17,10 @@
 package org.finra.hiveqlunit.script;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.SQLContext;
 import org.finra.hiveqlunit.resources.TextResource;
+
+import java.util.List;
 
 /**
  * Runs a single hql expression, with no heed for comments or scripts with multiple expressions
@@ -44,19 +46,19 @@ public class SingleExpressionScript implements HqlScript {
      * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      */
     @Override
-    public void runScript(HiveContext hqlContext) {
-        hqlContext.sql(expression);
+    public void runScript(SQLContext sqlContext) {
+        sqlContext.sql(expression);
     }
 
     /**
      * Runs the hql contained in the constructor given TextResource, treating it as a single
      * expression with no comments.
      *
-     * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an sqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      * @return a result set of Rows produced by running the hql script or expressions represented by this HqlScript
      */
     @Override
-    public Row[] runScriptReturnResults(HiveContext hqlContext) {
-        return hqlContext.sql(expression).collect();
+    public List<Row> runScriptReturnResults(SQLContext sqlContext) {
+        return sqlContext.sql(expression).collectAsList();
     }
 }

--- a/src/main/java/org/finra/hiveqlunit/script/SingleExpressionScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/SingleExpressionScript.java
@@ -43,7 +43,7 @@ public class SingleExpressionScript implements HqlScript {
      * Runs the hql contained in the constructor given TextResource, treating it as a single
      * expression with no comments.
      *
-     * @param hqlContext an HqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      */
     @Override
     public void runScript(SQLContext sqlContext) {

--- a/src/main/java/org/finra/hiveqlunit/script/SingleExpressionScript.java
+++ b/src/main/java/org/finra/hiveqlunit/script/SingleExpressionScript.java
@@ -43,7 +43,7 @@ public class SingleExpressionScript implements HqlScript {
      * Runs the hql contained in the constructor given TextResource, treating it as a single
      * expression with no comments.
      *
-     * @param sqlContext an SqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SQLContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      */
     @Override
     public void runScript(SQLContext sqlContext) {
@@ -54,7 +54,7 @@ public class SingleExpressionScript implements HqlScript {
      * Runs the hql contained in the constructor given TextResource, treating it as a single
      * expression with no comments.
      *
-     * @param sqlContext an sqlContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
+     * @param sqlContext an SQLContext, as provided by spark through the TestHiveServer TestRule, used to run hql expressions
      * @return a result set of Rows produced by running the hql script or expressions represented by this HqlScript
      */
     @Override

--- a/src/test/java/org/finra/hiveqlunit/resources/LocalFileResourceTest.java
+++ b/src/test/java/org/finra/hiveqlunit/resources/LocalFileResourceTest.java
@@ -31,7 +31,7 @@ import java.io.PrintStream;
 public class LocalFileResourceTest {
 
     @Rule
-    public static TemporaryFolder testFolder = new TemporaryFolder();
+    public TemporaryFolder testFolder = new TemporaryFolder();
 
     @Test
     public void providesCorrectInputStreamTest() {

--- a/src/test/java/org/finra/hiveqlunit/resources/TextLiteralResourceTest.java
+++ b/src/test/java/org/finra/hiveqlunit/resources/TextLiteralResourceTest.java
@@ -16,7 +16,7 @@
 
 package org.finra.hiveqlunit.resources;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TextLiteralResourceTest {

--- a/src/test/java/org/finra/hiveqlunit/resources/manipulation/Dos2UnixResourceTest.java
+++ b/src/test/java/org/finra/hiveqlunit/resources/manipulation/Dos2UnixResourceTest.java
@@ -16,7 +16,7 @@
 
 package org.finra.hiveqlunit.resources.manipulation;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.finra.hiveqlunit.resources.TextLiteralResource;
 import org.finra.hiveqlunit.resources.TextResource;
 import org.junit.Test;

--- a/src/test/java/org/finra/hiveqlunit/resources/manipulation/SubstituteVariableResourceTest.java
+++ b/src/test/java/org/finra/hiveqlunit/resources/manipulation/SubstituteVariableResourceTest.java
@@ -16,7 +16,7 @@
 
 package org.finra.hiveqlunit.resources.manipulation;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.finra.hiveqlunit.resources.TextLiteralResource;
 import org.finra.hiveqlunit.resources.TextResource;
 import org.junit.Test;

--- a/src/test/java/org/finra/hiveqlunit/resources/manipulation/VariableConfigResourceTest.java
+++ b/src/test/java/org/finra/hiveqlunit/resources/manipulation/VariableConfigResourceTest.java
@@ -1,6 +1,6 @@
 package org.finra.hiveqlunit.resources.manipulation;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.finra.hiveqlunit.resources.TextLiteralResource;
 import org.finra.hiveqlunit.resources.TextResource;
 import org.junit.Test;

--- a/src/test/java/org/finra/hiveqlunit/rules/SetUpHqlTest.java
+++ b/src/test/java/org/finra/hiveqlunit/rules/SetUpHqlTest.java
@@ -16,13 +16,14 @@
 
 package org.finra.hiveqlunit.rules;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.SQLContext;
 import org.finra.hiveqlunit.script.HqlScript;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SetUpHqlTest {
@@ -44,14 +45,14 @@ public class SetUpHqlTest {
 
         TestHiveServer dummyServer = new TestHiveServer() {
             @Override
-            public HiveContext getHiveContext() {
+            public SQLContext getSqlContext() {
                 return null;
             }
         };
 
         HqlScript dummyScript = new HqlScript() {
             @Override
-            public void runScript(HiveContext hqlContext) {
+            public void runScript(SQLContext sqlContext) {
                 Assert.assertFalse(scriptRun.get());
                 Assert.assertFalse(statementCalled.get());
 
@@ -59,7 +60,7 @@ public class SetUpHqlTest {
             }
 
             @Override
-            public Row[] runScriptReturnResults(HiveContext hqlContext) {
+            public List<Row> runScriptReturnResults(SQLContext sqlContext) {
                 Assert.fail();
                 return null;
             }

--- a/src/test/java/org/finra/hiveqlunit/rules/TearDownHqlTest.java
+++ b/src/test/java/org/finra/hiveqlunit/rules/TearDownHqlTest.java
@@ -16,13 +16,14 @@
 
 package org.finra.hiveqlunit.rules;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.hive.HiveContext;
+import org.apache.spark.sql.SQLContext;
 import org.finra.hiveqlunit.script.HqlScript;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TearDownHqlTest {
@@ -44,14 +45,14 @@ public class TearDownHqlTest {
 
         TestHiveServer dummyServer = new TestHiveServer() {
             @Override
-            public HiveContext getHiveContext() {
+            public SQLContext getSqlContext() {
                 return null;
             }
         };
 
         HqlScript dummyScript = new HqlScript() {
             @Override
-            public void runScript(HiveContext hqlContext) {
+            public void runScript(SQLContext sqlContext) {
                 Assert.assertFalse(scriptRun.get());
                 Assert.assertTrue(statementCalled.get());
 
@@ -59,7 +60,7 @@ public class TearDownHqlTest {
             }
 
             @Override
-            public Row[] runScriptReturnResults(HiveContext hqlContext) {
+            public List<Row> runScriptReturnResults(SQLContext sqlContext) {
                 Assert.fail();
                 return null;
             }

--- a/src/test/java/org/finra/hiveqlunit/script/ScriptSplitterTest.java
+++ b/src/test/java/org/finra/hiveqlunit/script/ScriptSplitterTest.java
@@ -16,7 +16,7 @@
 
 package org.finra.hiveqlunit.script;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ScriptSplitterTest {

--- a/userguides/WritingHiveQLUnitTests.md
+++ b/userguides/WritingHiveQLUnitTests.md
@@ -79,7 +79,7 @@ The TestDataLoader provides utility methods accesible from within test methods f
     public void test() {
         loader.loadDataIntoTable("src", new LocalFileResource("C:/cygwin64/home/K00001/testdata.txt"), "");
 
-        HiveContext sqlContext = hiveServer.getHiveContext();
+        HiveContext sqlContext = hiveServer.getSqlContext();
         Row[] results = sqlContext.sql("SELECT key FROM src WHERE key = 5").collect();
         Assert.assertEquals(3, results.length);
     }

--- a/userguides/WritingHiveQLUnitTests.md
+++ b/userguides/WritingHiveQLUnitTests.md
@@ -80,8 +80,8 @@ The TestDataLoader provides utility methods accesible from within test methods f
         loader.loadDataIntoTable("src", new LocalFileResource("C:/cygwin64/home/K00001/testdata.txt"), "");
 
         HiveContext sqlContext = hiveServer.getSqlContext();
-        Row[] results = sqlContext.sql("SELECT key FROM src WHERE key = 5").collect();
-        Assert.assertEquals(3, results.length);
+        List<Row> results = sqlContext.sql("SELECT key FROM src WHERE key = 5").collectAsList();
+        Assert.assertEquals(3, results.size());
     }
 
 ### SetUpHql ###

--- a/userguides/WritingHiveQLUnitTests.md
+++ b/userguides/WritingHiveQLUnitTests.md
@@ -39,10 +39,10 @@ The HqlScript interface abstracts how to parse and run an hql script on a hive s
     public static TestHiveServer hiveServer = new TestHiveServer();
 
     @Rule
-    public static TestDataLoader loader = new TestDataLoader(hiveServer);
+    public TestDataLoader loader = new TestDataLoader(hiveServer);
 
     @Rule
-    public static SetUpHql prepSrc =
+    public SetUpHql prepSrc =
             new SetUpHql(
                     hiveServer,
                     new MultiExpressionScript(
@@ -51,7 +51,7 @@ The HqlScript interface abstracts how to parse and run an hql script on a hive s
             );
 
     @Rule
-    public static TearDownHql cleanSrc =
+    public TearDownHql cleanSrc =
             new TearDownHql(
                     hiveServer,
                     new SingleExpressionScript(
@@ -71,7 +71,7 @@ The TestHiveServer constructs an instance of HiveContext, which provides access 
 ### TestDataLoader ###
 
     @Rule
-    public static TestDataLoader loader = new TestDataLoader(hiveServer);
+    public TestDataLoader loader = new TestDataLoader(hiveServer);
 
 The TestDataLoader provides utility methods accesible from within test methods for loading data out of a TextResource and into a Hive table.
 
@@ -79,7 +79,7 @@ The TestDataLoader provides utility methods accesible from within test methods f
     public void test() {
         loader.loadDataIntoTable("src", new LocalFileResource("C:/cygwin64/home/K00001/testdata.txt"), "");
 
-        HiveContext sqlContext = hiveServer.getSqlContext();
+        SQLContext sqlContext = hiveServer.getSqlContext();
         List<Row> results = sqlContext.sql("SELECT key FROM src WHERE key = 5").collectAsList();
         Assert.assertEquals(3, results.size());
     }


### PR DESCRIPTION
Removed JavaSparkContext and introduce sparkSession and SessionBuilder
Refactored code to use SQLContext instead of deprecated HiveContext
Upgraded POM to Spark 2.2.1
Upgraded POM to Junit 4.12
  